### PR TITLE
Update run_client to allow quotes

### DIFF
--- a/lua/luadev/luadev.lua
+++ b/lua/luadev/luadev.lua
@@ -20,7 +20,7 @@ COMMAND('run_self',function(ply,_,script,who)
 	RunOnSelf(script,CMD(who),MakeExtras(ply))
 end,true)
 
-COMMAND('run_client',function(ply,tbl,cmd,who)
+COMMAND('run_client',function(ply,tbl,script,who)
 
 	if !tbl[1] or !tbl[2] then Print("Syntax: lua_run_client (steamid/userid/uniqueid/part of name) script") return end
 
@@ -31,10 +31,21 @@ COMMAND('run_client',function(ply,tbl,cmd,who)
 		Print("Running script on "..tostring(cl:Name()))
 	end
 
-	table.remove(tbl,1)
-	local cmd=TableToString(tbl)
+	local _, e = script:find('^%s*"[^"]+')
+	if e then
+		script = script:sub(e+2)
+	else
+		local _, e = script:find('^%s*[^%s]+%s')
+		if not e then
+			Print("Invalid Command syntax.")
+			return
+		end
+		script = script:sub(e)
+	end
 
-	RunOnClient(cmd,cl,CMD(who),MakeExtras(ply))
+	script = script:Trim()
+
+	RunOnClient(script,cl,CMD(who),MakeExtras(ply))
 
 end)
 


### PR DESCRIPTION
Using TableToString to rebuild the script string from the argument table minus the first argument (player search string) causes double-quotes to disappear. This commit uses patterns to first check for a quoted argument and unquoted afterwards, and effectively removes it from the 'script' string, leaving our beloved double-quotes intact. Unmatched double quotes will be caught by the first check in the function, with tbl[2] being nil.

With TableToString:
>] l_run_client ^ print("a")
>[Luadev Server] print ( a )
><0:0:40320801|CSi. Xavier><run_client> running on Player [1][CSi. Xavier]

With pattern matching:
>] l_run_client ^ print("a")
>[Luadev Server] print("a")
><0:0:40320801|CSi. Xavier><run_client> running on Player [1][CSi. Xavier]

I am not 100% sure if my patterns are correct, but I haven't found a way to break them yet. Improvements / suggestions are more than welcome.