### PR TITLE
Fix ability to server luarun using SteamID spoof

### DIFF
--- a/lua/luadev/luadev_sh.lua
+++ b/lua/luadev/luadev_sh.lua
@@ -530,6 +530,9 @@ end
 local sv_allowcslua = GetConVar 'sv_allowcslua'
 
 function CanLuaDev(ply,script,command,target,target_ply,extra)
+	if SERVER and not ply:IsFullyAuthenticated() then
+		return false, "Your SteamID wasn't fully authenticated, try restarting Steam."
+	end
 	local ret,x = hook.Run("CanLuaDev",ply,script,command,target,target_ply,extra)
 	if ret~=nil then return ret,x end
 	local ret,x = hook.Run("LuaDevIsPlayerAllowed", ply, script or "")


### PR DESCRIPTION
There is a way to steal a player's authorization token and use it to access any privileges under his SteamID