### PR TITLE
fix: harden luadev runtime error paths

### DIFF
--- a/lua/autorun/easylua.lua
+++ b/lua/autorun/easylua.lua
@@ -66,7 +66,7 @@ function easylua.Print(...)
 		Msg(string.format("[ELua %s] ", IsValid(me) and me:Nick() or "Sv"))
 
 		for key, value in pairs(args) do
-			str = str .. type(value) == "string" and value or luadata.ToString(value) or tostring(value)
+			str = str .. (type(value) == "string" and value or (luadata and luadata.ToString(value) or tostring(value)))
 
 			if key ~= #args then
 				str = str .. ","
@@ -84,7 +84,7 @@ if SERVER then
 		local now = RealTime()
 		local nextspam = spams[pl] or 0
 		if now>nextspam then
-			nextspam = now + len>100 and 3 or 1
+			nextspam = now + (len>100 and 3 or 1)
 			spams[pl] = nextspam
 			return true
 		else
@@ -286,7 +286,7 @@ function easylua.FindEntity(str)
 	end
 
 	-- search RealName
-	if _R.Player.RealName then
+	if _R.Player.RealNick then
 		for _, ply in ipairs(player.GetAll()) do
 			if comparenick(ply:RealNick(), str) then
 				return ply
@@ -353,6 +353,7 @@ function easylua.FindEntity(str)
 			end
 		end
 
+		if #found == 0 then return NULL end
 		return found[math.Clamp(idx%#found, 1, #found)] or NULL
 	end
 end
@@ -435,7 +436,10 @@ function easylua.Start(ply)
 
 	ply = ply or CLIENT and LocalPlayer() or nil
 
-	if not ply or not IsValid(ply) then return end
+	if not ply or not IsValid(ply) then
+		started = false
+		return
+	end
 
 	local vars = {}
 		local trace = util.QuickTrace(ply:EyePos(), ply:GetAimVector() * 10000, {ply, ply:GetVehicle()})
@@ -465,7 +469,9 @@ function easylua.Start(ply)
 		vars.length = trace.StartPos:Distance(trace.HitPos)
 
 		vars.copy = s.CopyToClipboard
-		vars.create = s.CreateEntity
+		if SERVER then
+			vars.create = s.CreateEntity
+		end
 		vars.prints = s.PrintOnServer
 
 		if vars.this:IsValid() then
@@ -501,7 +507,7 @@ function easylua.End()
 
 	if s.vars then
 		for key, value in pairs(s.vars) do
-			if s.oldvars and s.oldvars[key] then
+			if s.oldvars and s.oldvars[key] ~= nil then
 				rawset(_G, key, s.oldvars[key])
 			else
 				rawset(_G, key, nil)
@@ -774,8 +780,13 @@ do -- all
 	them = CreateAllFunction(function()
 		local me = _G.me
 		local we = _G.we or {}
-		table.RemoveByValue(we, me)
-		return we
+		local t = {}
+		for k,v in ipairs(we) do
+			if v ~= me then
+				t[#t+1] = v
+			end
+		end
+		return t
 	end)
 	friends = CreateAllFunction(function()
 		local me = _G.me

--- a/lua/autorun/server/luadev_chatcmds.lua
+++ b/lua/autorun/server/luadev_chatcmds.lua
@@ -47,15 +47,24 @@ add("lc", function(ply, line, target)
 end)
 
 add("lsc", function(ply, line, target)
-	local script = string.sub(line, string.find(line, target, 1, true)+#target+1)
+	if not line or line=="" or not target or target=="" then return false,"invalid target" end
+	local target_start = string.find(line, target, 1, true)
+	if not target_start then return false,"invalid target" end
+
+	local script = string.sub(line, target_start+#target+1):Trim()
+	if script=="" then return false,"invalid script" end
 	if luadev.ValidScript then local valid,err = luadev.ValidScript(script,'lsc') if not valid then return false,err end end
 	
-	easylua.Start(ply) -- for _G.we -> #us
-	local ent = easylua.FindEntity(target)
-	if type(ent) == 'table' then
-		ent = ent.get()
-	end
+	local ok, ent = pcall(function()
+		easylua.Start(ply) -- for _G.we -> #us
+		local found = easylua.FindEntity(target)
+		if type(found) == 'table' then
+			found = found.get()
+		end
+		return found
+	end)
 	easylua.End()
+	if not ok then return false,ent end
 	
 	return luadev.RunOnClient(script,  ent,  X(ply,"lsc"), {ply=ply})
 end)
@@ -96,9 +105,9 @@ add("keys", function(ply, line, table, search)
 	if not line or line=="" then return end
 	if luadev.ValidScript then local valid,err = luadev.ValidScript('x('..table..')','keys') if not valid then return false,err end end
 
-	search = search and search:lower() or ""
+	search = ("%q"):format(search and search:lower() or "")
 	return luadev.RunOnServer(
-		"local t={} for k,v in pairs(" .. table .. ") do t[#t+1]=tostring(k) end table.sort(t) for k,v in pairs(t) do if string.find(v:lower(),\"" .. search .. "\",1,true) then print(v) end end",
+		"local t={} for k,v in pairs(" .. table .. ") do t[#t+1]=tostring(k) end table.sort(t) for k,v in pairs(t) do if string.find(v:lower()," .. search .. ",1,true) then print(v) end end",
 		X(ply,"keys"), {ply=ply}
 	)
 end)
@@ -107,9 +116,9 @@ add("keysm", function(ply, line, table, search)
 	if not line or line=="" then return end
 	if luadev.ValidScript then local valid,err = luadev.ValidScript('x('..table..')','keys') if not valid then return false,err end end
 
-	search = search and search:lower() or ""
+	search = ("%q"):format(search and search:lower() or "")
 	return luadev.RunOnClient(
-		"local t={} for k,v in pairs(" .. table .. ") do t[#t+1]=tostring(k) end table.sort(t) for k,v in pairs(t) do if string.find(v:lower(),\"" .. search .. "\",1,true) then print(v) end end",
+		"local t={} for k,v in pairs(" .. table .. ") do t[#t+1]=tostring(k) end table.sort(t) for k,v in pairs(t) do if string.find(v:lower()," .. search .. ",1,true) then print(v) end end",
 		ply, X(ply,"keysm"), {ply=ply}
 	)
 end)

--- a/lua/autorun/tinylua.lua
+++ b/lua/autorun/tinylua.lua
@@ -131,13 +131,13 @@ local function buildParser(input)
 
 	if argStr and funcStr then
 		local codeFull = string.format("return function(%s)\n%s\nend", argStr, makePrefix(funcStr))
-		local funcFactory = CompileString(codeFull, "funcfactory")
+		local funcFactory = CompileString(codeFull, "funcfactory", false)
 
-		if getfenv(1) then
+		if isfunction(funcFactory) and getfenv(1) then
 			setfenv(funcFactory, getfenv(1))
 		end
 
-		if funcFactory then
+		if isfunction(funcFactory) then
 			return funcFactory()
 		end
 	end

--- a/lua/luadev/luadev_sh.lua
+++ b/lua/luadev/luadev_sh.lua
@@ -201,7 +201,7 @@ end
 				if CLIENT then
 					local tbl = _G.EFFECT _G.EFFECT = nil
 					if tbl then
-						effects.Register(_G.EFFECT,val)
+						effects.Register(tbl,val)
 					end
 				end
 			end,
@@ -246,7 +246,7 @@ end
 		end
 		if not cl then
 			for k,v in pairs(player.GetAll()) do
-				if string.find(v:Name(),plyid) then
+				if string.find(v:Name(),plyid,1,true) then
 					cl=v
 					break
 				end
@@ -399,6 +399,7 @@ function Run(script,info,extra)
 	-- Compiling
 
 	local func = LUADEV_COMPILE_STRING(script,tostring(info),false)
+	local compileerr
 	if not func or isstring( func )  then  compileerr = func or true  func = false end
 
 	local ret = LuaDevProcess(STAGE_COMPILED,script,info,extra,func)
@@ -452,7 +453,12 @@ function Run(script,info,extra)
 	end
 
 	local LUADEV_EXECUTE_FUNCTION=xpcall
-	local returnvals = {LUADEV_EXECUTE_FUNCTION(func,LUADEV_TRACEBACK,args and unpack(args) or nil)}
+	local returnvals
+	if args then
+		returnvals = {LUADEV_EXECUTE_FUNCTION(func,LUADEV_TRACEBACK,unpack(args))}
+	else
+		returnvals = {LUADEV_EXECUTE_FUNCTION(func,LUADEV_TRACEBACK)}
+	end
 	local ok = returnvals[1] table.remove(returnvals,1)
 
 	-- STAGE_POST
@@ -468,6 +474,7 @@ end
 
 
 function RealFilePath(name)
+	if not isstring(name) or name=="" then return nil end
 	local searchpath = "MOD"
 
 	local RelativePath='lua/'..name
@@ -587,8 +594,8 @@ function COMMAND(str,func,complete)
 			func(pl,cmds,strcmd,id)
 		end)
 	else
-		concommand.Add('lua_'..str,function(_,_,cmds,strcmd)
-			func(pl,cmds,strcmd,str)
+		concommand.Add('lua_'..str,function(ply,_,cmds,strcmd)
+			func(IsValid(ply) and ply or LocalPlayer(),cmds,strcmd,str)
 		end,(not complete and function(...) return AutoComplete(str,...) end) or nil)
 	end
 end

--- a/lua/luadev/luadev_sv.lua
+++ b/lua/luadev/luadev_sv.lua
@@ -38,7 +38,7 @@ local function ClearTargets(targets)
 	local i=1
 	local target=targets[i]
 	while target do
-		if not IsValid(target) then
+		if not IsValid(target) or not target:IsPlayer() then
 			table.remove(targets,i)
 			i=i-1
 		end
@@ -118,7 +118,8 @@ end
 
 
 function RunOnShared(...)
-	RunOnClients(...)
+	local ok,err = RunOnClients(...)
+	if not ok then return ok,err end
 	return RunOnServer(...)
 end
 
@@ -150,6 +151,12 @@ function _ReceivedData(len, ply)
 	
 	local script = ReadCompressed() -- WriteCompressed(data)
 	local decoded=net.ReadTable()
+	if not isstring(script) then
+		return RejectCommand(ply,"bad script")
+	end
+	if not istable(decoded) then
+		return RejectCommand(ply,"bad data table")
+	end
 	decoded.src=script
 	
 	
@@ -160,6 +167,9 @@ function _ReceivedData(len, ply)
 	if not istable(extra) then
 		return RejectCommand(ply,"bad extra table")
 	end
+	if target~=TO_SERVER and target~=TO_CLIENT and target~=TO_CLIENTS and target~=TO_SHARED then
+		return RejectCommand(ply,"bad target")
+	end
 	extra.ply=ply
 	
 	local can, msg = CanLuaDev(ply,script,nil,target,target_ply,extra)
@@ -167,7 +177,7 @@ function _ReceivedData(len, ply)
 		return RejectCommand(ply,msg)
 	end
 
-	if TransmitHook(data)~=nil then return end
+	if TransmitHook(decoded)~=nil then return end
 	
 	local identifier = GetPlayerIdentifier(ply,info)
 	local ok,err

--- a/lua/luadev/socketdev.lua
+++ b/lua/luadev/socketdev.lua
@@ -111,20 +111,49 @@ local methods = {
 	end
 }
 
-local sock = assert(socket.tcp())
-assert(sock:bind("127.0.0.1", 27099))
-sock:settimeout(0)
+local socketHook = "LuaDev-Socket"
+
+if luadev.socketdev then
+	hook.Remove("Think", socketHook)
+	pcall(luadev.socketdev.close, luadev.socketdev)
+	luadev.socketdev = nil
+end
+
+local function closeSocket(sock)
+	if not sock then return end
+	pcall(sock.shutdown, sock)
+	pcall(sock.close, sock)
+end
+
+local sock, err = socket.tcp()
+if not sock then
+	luadevPrint("Unable to create socket:", err)
+	return
+end
+
 sock:setoption("reuseaddr", true)
-assert(sock:listen(0))
+local ok, err = sock:bind("127.0.0.1", 27099)
+if not ok then
+	luadevPrint("Unable to bind SocketDev:", err)
+	closeSocket(sock)
+	return
+end
+sock:settimeout(0)
+local ok, err = sock:listen(0)
+if not ok then
+	luadevPrint("Unable to listen for SocketDev:", err)
+	closeSocket(sock)
+	return
+end
 luadev.socketdev = sock -- in case something fucks up, we wanna be able to call sock:close() later
 
-hook.Add("Think", "LuaDev-Socket", function()
+hook.Add("Think", socketHook, function()
 	local cl = sock:accept()
 	if not cl then return end
 
 	if cl:getpeername() ~= "127.0.0.1" then
 		luadevPrint("Refused", cl:getpeername())
-		cl:shutdown()
+		closeSocket(cl)
 		return
 	end
 
@@ -140,8 +169,11 @@ hook.Add("Think", "LuaDev-Socket", function()
 	end
 
 	if method and methods[method] then
-		pcall(methods[method], cl)
+		local ok, err = pcall(methods[method], cl)
+		if not ok then
+			luadevPrint("SocketDev method error:", err)
+		end
 	end
 
-	cl:shutdown()
+	closeSocket(cl)
 end)


### PR DESCRIPTION
﻿Fixes actual runtime errors I hit while testing LuaDev reload/error paths:

- inbound client dispatch calls `LuaDevTransmit` with an undefined `data` variable, so hooks receive nil and cannot inspect/veto the command
- `lua_send_effect` clears `_G.EFFECT` and then passes nil to `effects.Register`, so effect refresh is broken
- malformed net payloads and non-player client targets can error before a clean reject
- `lua_run_sh`/`RunOnShared` can still run server-side after the client send fails
- easylua/tinylua helper paths have a few crash cases: print string concat precedence, empty entity matches, bad arrow parser input, `/lsc` target parsing, and unescaped key search strings
- SocketDev reloads can leave the old listener/accepted sockets around, then fail on bind next load

If this is still too wide, I can split it into smaller PRs for server dispatch, helper crashes, and SocketDev reload cleanup.

Checked with:
- `git diff --check origin/master...HEAD`
- Garry's Mod `CompileString` smoke in both server and client realms